### PR TITLE
Remove unnecessary "Regular User" group

### DIFF
--- a/calorie_tracker/accounts/migrations/0001_initial.py
+++ b/calorie_tracker/accounts/migrations/0001_initial.py
@@ -1,10 +1,10 @@
-from accounts.constants import ADMIN_GROUP, REGULAR_USER_GROUP, USER_MANAGER_GROUP
+from accounts.constants import ADMIN_GROUP, USER_MANAGER_GROUP
 from django.contrib.auth.models import Group
 from django.db import migrations
 
 
 def create_groups(apps, schema_editor):
-    group_names = [ADMIN_GROUP, REGULAR_USER_GROUP, USER_MANAGER_GROUP]
+    group_names = [ADMIN_GROUP, USER_MANAGER_GROUP]
 
     for group_name in group_names:
         Group.objects.get_or_create(name=group_name)

--- a/calorie_tracker/accounts/tests/test_groups.py
+++ b/calorie_tracker/accounts/tests/test_groups.py
@@ -1,12 +1,12 @@
 import pytest
-from accounts.constants import ADMIN_GROUP, REGULAR_USER_GROUP, USER_MANAGER_GROUP
+from accounts.constants import ADMIN_GROUP, USER_MANAGER_GROUP
 from django.contrib.auth.models import Group
 
 
 @pytest.mark.django_db
 def test_groups_are_persisted():
     """Test that groups are persisted after migrations."""
-    groups = [REGULAR_USER_GROUP, USER_MANAGER_GROUP, ADMIN_GROUP]
+    groups = [USER_MANAGER_GROUP, ADMIN_GROUP]
 
     for group in groups:
         assert Group.objects.filter(name=group).exists()


### PR DESCRIPTION
This is removed since a user that is not a User Manager or Admin can be considered a Regular User.